### PR TITLE
Valid error return when API is called with empty POST document.

### DIFF
--- a/CryptoBook/validators.py
+++ b/CryptoBook/validators.py
@@ -1,4 +1,4 @@
-from cerberus import Validator
+from cerberus import Validator, DocumentError
 from datetime import datetime
 
 def check_historical_data(request):
@@ -12,7 +12,10 @@ def check_historical_data(request):
                 'start': {'type': 'datetime', 'coerce': date},
                 'end': {'type': 'datetime', 'coerce': date}}
 
-    if v.validate(request):
-        return True, {}
-    else:
-        return False, v.errors
+    try:
+        if v.validate(request):
+            return True, {}
+        else:
+            return False, v.errors
+    except DocumentError:
+        return False, {'Document is missing.'}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM python:3
 
-# Exposes this container's port 4141 to other containers.
+# Exposes this container's port 9900 to other containers.
 EXPOSE 9900
 
 # Sets the workdir of our container to dir below.
-WORKDIR /usr/src/app
+WORKDIR /usr/src/app/CryptoBook
 
 # Copies our project and its requirements.txt over to the dir above.
 COPY requirements.txt .
 COPY config.yml .
-COPY CryptoBook .
+COPY CryptoBook/ ./CryptoBook
 
 # Installs the requirements of our project.
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Runs the API when the container is ran.
-CMD [ "python", "api.py" ]
+CMD [ "python", "CryptoBook/api.py" ]


### PR DESCRIPTION
Fixed issue within the API in which the server did not have a valid response for missing POST document when calling `historical_data` endpoint. The server now responds the following:

```json
{
    "description": "The server received the request, but the request was invalid.",
    "error": "invalid_request",
    "keys": [
        "Document is missing."
    ]
}
```