### PR TITLE
Removed the unnecessary conversion of the Time column to DateTime.

### DIFF
--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -83,7 +83,4 @@ async def historical_data(symbol, ex, timeframe, start, end):
     # Cuts off the DataFrame at the ending time.
     df = df[df.Time <= exchange.parse8601(data_end.isoformat())]
 
-    # Converts the df Timestamp column into DateTime objects.
-    df['Time'] = pd.to_datetime(df['Time'], unit='ms')
-
     return df.to_json()


### PR DESCRIPTION
Removed the time-wasting recomputation of the DataFrame inside the `historical_data` function within util. Time improvement should be noticeable for large amounts of data.

```python
# Converts the df Timestamp column into DateTime objects.
df['Time'] = pd.to_datetime(df['Time'], unit='ms')
```