### PR TITLE
Bypassing CloudFare verification system via cfscrape.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 language: python
 
 python:
+    - "3.5"
     - "3.6"
     - "3.7"
 install:

--- a/CryptoBook/api.py
+++ b/CryptoBook/api.py
@@ -48,4 +48,4 @@ async def api_historical_data(request):
 # 'pragma' line below insures Coverall does not bother checking this function for coverage.
 if __name__ == '__main__': # pragma: no cover
     host, port = load_config()
-    app.run(host=config['host'], port=config['port'])
+    app.run(host=host, port=port)

--- a/CryptoBook/api.py
+++ b/CryptoBook/api.py
@@ -3,6 +3,7 @@ from validators import check_exchange_info, check_historical_data
 
 from sanic.response import json
 from sanic import Sanic
+import asyncio
 import yaml
 import os
 
@@ -23,27 +24,32 @@ async def api_get_ip(request):
 @app.route('/api/v1/cryptobook/exchange/<exchange_name:[A-z]+>')
 async def api_exchange_info(request, exchange_name):
     """ Returns information about the exchange. """
-    valid_request, status, response = check_exchange_info(exchange_name)
+    valid_request, status, response = await check_exchange_info(exchange_name)
     if not valid_request:
         return json(response, status=status)
     else:
-        return json(await exchange_info(exchange = exchange_name, exchange_object = response['exchange-object']), status=200)
+        return json(await exchange_info(exchange = exchange_name), status=200)
 
 @app.route('/api/v1/cryptobook/historical', methods=["POST"])
 async def api_historical_data(request):
     """ Returns historical exchange data. """
 
-    valid_request, status, response = check_historical_data(request.json)
+    valid_request, status, response = await check_historical_data(request.json)
     if not valid_request:
         return json(response, status=status)
     else:
-        return json(await historical_data(exchange=request.json['exchange'],
-                                          symbol=request.json['symbol'],
-                                          timeframe=request.json['timeframe'],
-                                          start=request.json['start'],
-                                          end=request.json['end'],
-                                          exchange_object = response['exchange-object']),
-                                          status=200)
+        req = {
+            'exchange':request.json['exchange'],
+            'symbol':request.json['symbol'],
+            'timeframe':request.json['timeframe'],
+            'start':request.json['start'],
+            'end':request.json['end']
+        }
+
+        if 'cfbypass' in request.json:
+            return json(await historical_data(**req, cfbypass=request.json['cfbypass']), status=200)
+        else:
+            return json(await historical_data(**req), status=200)
 
 # 'pragma' line below insures Coverall does not bother checking this function for coverage.
 if __name__ == '__main__': # pragma: no cover

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from dateutil.parser import parse
 import pandas as pd
+import cfscrape
 import asyncio
 import aiohttp
 import ccxt
@@ -56,6 +57,7 @@ async def historical_data(exchange, symbol, timeframe, start, end, exchange_obje
     if exchange_object:
         ex = exchange_object
         ex.enableRateLimit = False
+        ex.session = cfscrape.create_scraper()
     else:
         ex = getattr (ccxt, exchange) ()
 

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -47,6 +47,7 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
         timeframe (str): Timeframe of the data.
         start (str): Beginning date and time of the data.
         end (str): Ending date and time of the data.
+        cfbypass (bool): Optional flag to indicated whether or not do bypass CloudFlare checks (read notes).
 
     Returns:
         str: JSON data with market exchange information.
@@ -109,7 +110,7 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
     df = df.append(dataframes, ignore_index=True)
 
     # Cuts off the DataFrame at the ending time.
-    df = df[df.Time <= time_end]
+    #df = df[df.Time <= time_end]
 
     # Removes duplicates due to server responding with more values per call.
     df = df.drop_duplicates(keep='first')

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -4,7 +4,9 @@ import pandas as pd
 import cfscrape
 import asyncio
 import aiohttp
+
 import ccxt
+import ccxt.async_support as ccxt_async
 
 async def get_ip():
     """ Fetches and returns the external IP of the server for testing purposes. """
@@ -54,31 +56,55 @@ async def historical_data(exchange, symbol, timeframe, start, end, exchange_obje
         str: JSON data with market exchange information.
     """
 
+    # @todo Make sure if exchange_object is passed, it is async.
     if exchange_object:
         ex = exchange_object
         ex.enableRateLimit = False
         ex.session = cfscrape.create_scraper()
     else:
-        ex = getattr (ccxt, exchange) ()
+        ex = getattr (ccxt_async, exchange) ()
 
     # Configuration settings for the DataFrame.
     header = ['Time', 'Open', 'High', 'Low', 'Close', 'Volume']
     df = pd.DataFrame(columns=header)
 
-    data_start = parse(start)
-    data_end = parse(end)
+    # Setting our start and ending variables as given by the input.
+    time_start = ex.parse8601(parse(start).isoformat())
+    time_end = ex.parse8601(parse(end).isoformat())
 
-    # Re-formats the `start` key to proper ISO8601.
-    current = ex.parse8601(parse(start).isoformat())
+    # Getting the first DataFrame result to measure the size.
+    resp_first = await ex.fetch_ohlcv(symbol, timeframe, time_start)
 
-    # Begins while loop.
-    while data_start < data_end:
-        df = df.append(pd.DataFrame(data = ex.fetch_ohlcv(symbol, timeframe, current), columns=header), ignore_index=True)
+    # The interval of data in which the market is replying by.
+    resp_interval = resp_first[-1][0] - resp_first[0][0]
 
-        current = df[-1:]['Time'].iloc[0]
-        data_start = data_start + timedelta(microseconds=current)
+    # Computes all of the datetime we must request from the exchange.
+    times = []
+    while time_start < time_end:
+        time_start += resp_interval + 60000 # @todo make this dynamic to the interval given.
+        times.append(time_start)
+
+    # Create a DataFrame with the first response.
+    df = df.append(pd.DataFrame(data = resp_first, columns=header), ignore_index=True)
+
+    # Gathers all of the results in order.
+    responses = await asyncio.gather(*[ex.fetch_ohlcv(symbol, timeframe, time) for time in times])
+
+    # Appends all of our results to the DataFrame.
+    dataframes = [pd.DataFrame(data = response, columns=header) for response in responses]
+    df = df.append(dataframes, ignore_index=True)
+
+    # Closes the connection with the exchange (required due to asynchronous support).
+    await ex.close()
+
+    # @todo Ensure that the time is not getting cut-off for other exchanges.
+    # @desc This is due to parse8601 and the manner in which the specific market returns a timestamp. Ensure correct parser is being used.
 
     # Cuts off the DataFrame at the ending time.
-    df = df[df.Time <= ex.parse8601(data_end.isoformat())]
+    df = df[df.Time <= time_end]
 
+    # Removes duplicates due to server responding with more values per call.
+    df = df.drop_duplicates(keep='first')
+
+    # Return the DataFrame as a dictionary.
     return df.to_dict()

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -119,4 +119,4 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
         await ex.close()
 
     # Return the DataFrame as a dictionary.
-    return df.to_dict()
+    return df.to_dict(orient='split')

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -115,6 +115,7 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
     # Removes duplicates due to server responding with (sometimes) duplicate values.
     df = df.drop_duplicates(keep='first')
 
+    # Must close connection with market if using ccxt asynchronously. 
     if not cfbypass:
         await ex.close()
 

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -32,11 +32,17 @@ async def exchange_info(exchange):
     # Loads the market.
     await ex.load_markets()
 
-    # Returns the information.
-    return { 'exchange': exchange,
+    # Gathers market data.
+    data = { 'exchange': exchange,
              'symbols': ex.symbols,
              'timeframes': ex.timeframes,
              'historical': ex.has['fetchOHLCV']}
+
+    # Closes the market connection due to async ccxt.
+    await ex.close()
+
+    # Returns the information.
+    return data
 
 async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=False):
     """ Returns historical data of any market.
@@ -115,7 +121,7 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
     # Removes duplicates due to server responding with (sometimes) duplicate values.
     df = df.drop_duplicates(keep='first')
 
-    # Must close connection with market if using ccxt asynchronously. 
+    # Must close connection with market if using ccxt asynchronously.
     if not cfbypass:
         await ex.close()
 

--- a/CryptoBook/validators.py
+++ b/CryptoBook/validators.py
@@ -10,10 +10,10 @@ def check_exchange_info(exchange):
     Args:
         exchange (str): The name of the exchange to check.
 
-    Returns:
-        bool: Boolean representing whether or not check was successfull or failure.
-        int: HTTP code corresponding to the data validation. None if return bool above is true.
-        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
+    :returns:
+        - **valid_request** (*bool*): Boolean representing whether or not check was successfull or failure.
+        - **status** (*int*): HTTP code corresponding to the data validation. None if return bool above is true.
+        - **response** (*dict*): The response by the validator; either an error, or the loaded ccxt exchange object.
     """
 
     try:
@@ -30,10 +30,10 @@ def check_historical_data(request):
     Args:
         request (dict): The request sent into the server.
 
-    Returns:
-        bool: Boolean representing whether or not check was successfull or failure.
-        int: HTTP code corresponding to the data validation. None if return bool above is true.
-        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
+    :returns:
+        - **valid_request** (*bool*): Boolean representing whether or not check was successfull or failure.
+        - **status** (*int*): HTTP code corresponding to the data validation. None if return bool above is true.
+        - **response** (*dict*): The response by the validator; either an error, or the loaded ccxt exchange object.
     """
 
     # Creates the validator class and schema to check the requests' params.

--- a/CryptoBook/validators.py
+++ b/CryptoBook/validators.py
@@ -5,7 +5,17 @@ from sanic.response import json
 import ccxt
 
 def check_exchange_info(exchange):
-    # Checks to see if the exchange is valid.
+    """ Checks to see if the exchange is valid.
+
+    Args:
+        exchange (str): The name of the exchange to check.
+
+    Returns:
+        bool: Boolean representing whether or not check was successfull or failure.
+        int: HTTP code corresponding to the data validation. None if return bool above is true.
+        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
+    """
+
     try:
         ex = getattr (ccxt, exchange) ()
     except AttributeError:
@@ -22,7 +32,8 @@ def check_historical_data(request):
 
     Returns:
         bool: Boolean representing whether or not check was successfull or failure.
-        dict: Errors corresponding to the data validation. Empty if return bool is true.
+        int: HTTP code corresponding to the data validation. None if return bool above is true.
+        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
     """
 
     # Creates the validator class and schema to check the requests' params.

--- a/CryptoBook/validators.py
+++ b/CryptoBook/validators.py
@@ -39,6 +39,9 @@ async def check_historical_data(request):
         - **response** (*dict*): The response by the validator; details about an error.
     """
 
+    # @todo Add validation for fetchOHLCV function.
+    # @description Due to the nature of some exchanges, their reply is not always historical. Therefore, there needs to be a manner in which the verifier checks to ensure the market will _only_ return the proper historical data asked by the user. 
+
     # Creates the validator class and schema to check the requests' params.
     v = Validator()
     date = lambda s: datetime.strptime(s, '%Y-%m-%d %H:%M:%S')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM nikolaik/python-nodejs:latest
 
 # Exposes this container's port 9900 to other containers.
 EXPOSE 9900

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM nikolaik/python-nodejs:latest
+FROM python:3
+
+# Install NodeJS to the Alpine container (depedency).
+RUN apt-get -y update
+RUN apt-get -y install nodejs
 
 # Exposes this container's port 9900 to other containers.
 EXPOSE 9900

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -153,4 +153,4 @@ Historical Data
 
     .. sourcecode:: python
 
-        df = pd.read_json(resp)
+        df = pd.read_json(resp, orient='split')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,7 +88,50 @@ Historical Data
             "symbol": "ETH/BTC",
             "timeframe": "1m",
             "start": "2018-01-01 00:00:00",
-            "end": "2018-05-01 00:00:00"
+            "end": "2018-01-01 00:05:00"
+        }
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 543
+        Content-Type: application/json
+        Keep-Alive: 5
+
+        {
+            "Close": {
+                "0": 0.05352,
+                "...",
+                "5": 0.053588
+            },
+            "High": {
+                "0": 0.053613,
+                "...",
+                "5": 0.053654
+            },
+            "Low": {
+                "0": 0.053496,
+                "...",
+                "5": 0.053567
+            },
+            "Open": {
+                "0": 0.053586,
+                "...",
+                "5": 0.053573
+            },
+            "Time": {
+                "0": 1514764800000,
+                "...",
+                "5": 1514765100000
+            },
+            "Volume": {
+                "0": 162.312,
+                "...",
+                "5": 194.333
+            }
         }
 
     :jsonparam string exchange: The name of the exchange.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -139,8 +139,13 @@ Historical Data
     :jsonparam string timeframe: Timeframe of the data.
     :jsonparam string start: Beginning date and time of the data.
     :jsonparam string end: Ending date and time of the data.
+    :jsonparam bool cfbypass: (optional) Flag to indicate whether or not to bypass CloudFlare checking (read more below).
     :statuscode 200: No error.
     :statuscode 404: Resource not found.
+
+    **Note on cfbypass Flag**
+
+    To bypass CloudFlare this library is using the open source `cfscrape <https://pypi.org/project/cfscrape/>`_ library, which unfortunately does not support asynchronous requests with `aiohttp`. Therefore, if enabled, the scraper will not run with asynchronous capability.
 
     **Parsing data**:
 

--- a/examples/historical-pandas-cfbypass.py
+++ b/examples/historical-pandas-cfbypass.py
@@ -4,12 +4,12 @@ import requests
 import json
 
 data = {
-    'exchange':'binance',
+    'exchange':'coinbasepro',
     'symbol':'ETH/BTC',
     'timeframe':'1m',
     'start':'2018-01-01 00:00:00',
-    'end':'2019-01-01 00:00:00',
-    'cfbypass': False # Optional flag if exchange uses CloudFlare.
+    'end':'2018-01-05 00:00:00',
+    'cfbypass': True # Optional flag if exchange uses CloudFlare.
 }
 request_before = datetime.now()
 

--- a/examples/historical-pandas.py
+++ b/examples/historical-pandas.py
@@ -15,10 +15,7 @@ data = {
 r = requests.post(url="http://0.0.0.0:9900/api/v1/cryptobook/historical", data=json.dumps(data))
 
 # Reads the request.
-df = pd.read_json(r.text)
-
-# Organizes the DataFrame by index.
-df = df.sort_index()
+df = pd.read_json(r.text, orient='split')
 
 # Converts the Time column to DateTime objects.
 df['Time'] = pd.to_datetime(df['Time'], unit='ms')

--- a/examples/historical-pandas.py
+++ b/examples/historical-pandas.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import requests
+import json
+
+data = {
+    'exchange':'binance',
+    'symbol':'ETH/BTC',
+    'timeframe':'1m',
+    'start':'2018-01-01 00:00:00',
+    'end':'2018-01-05 00:00:00',
+    'cfbypass': False # Optional flag if exchange uses CloudFlare.
+}
+
+# Sends a request to the server with the data provided above.
+r = requests.post(url="http://0.0.0.0:9900/api/v1/cryptobook/historical", data=json.dumps(data))
+
+# Reads the request.
+df = pd.read_json(r.text)
+
+# Organizes the DataFrame by index.
+df = df.sort_index()
+
+# Converts the Time column to DateTime objects.
+df['Time'] = pd.to_datetime(df['Time'], unit='ms')
+
+# Prints the DataFrame.
+print(df.to_string())

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ pyyaml
 aiohttp
 pandas
 cerberus
+cfscrape

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@ pyyaml
 aiohttp
 pandas
 cerberus
+cfscrape
 
 pytest
 pytest-asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ class Test_historical_data(object):
         resp = await application.post('/api/v1/cryptobook/historical', data = json.dumps(data))
         resp_json = await resp.json()
         assert resp.status == 200
-        assert resp_json.keys() == set(['Time', 'Open', 'High', 'Low', 'Close', 'Volume'])
+        assert resp_json.keys() == set(['index', 'columns', 'data'])
 
     async def test_proper_input_with_cfbypass(self, application):
         """ Checks valid response is correctly replied to. """
@@ -77,9 +77,8 @@ class Test_historical_data(object):
         }
         resp = await application.post('/api/v1/cryptobook/historical', data = json.dumps(data))
         resp_json = await resp.json()
-        print(resp_json)
         assert resp.status == 200
-        assert resp_json.keys() == set(['Time', 'Open', 'High', 'Low', 'Close', 'Volume'])
+        assert resp_json.keys() == set(['index', 'columns', 'data'])
 
     async def test_inproper_input(self, application):
         """ Checks invalid response is correctly replied to. """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,22 @@ class Test_historical_data(object):
         assert resp.status == 200
         assert resp_json.keys() == set(['Time', 'Open', 'High', 'Low', 'Close', 'Volume'])
 
+    async def test_proper_input_with_cfbypass(self, application):
+        """ Checks valid response is correctly replied to. """
+        data = {
+            'exchange': 'binance',
+            'symbol': 'ETH/BTC',
+            'timeframe': '1m',
+            'start': '2018-01-01 00:00:00',
+            'end': '2018-05-01 00:00:00',
+            'cfbypass': True
+        }
+        resp = await application.post('/api/v1/cryptobook/historical', data = json.dumps(data))
+        resp_json = await resp.json()
+        print(resp_json)
+        assert resp.status == 200
+        assert resp_json.keys() == set(['Time', 'Open', 'High', 'Low', 'Close', 'Volume'])
+
     async def test_inproper_input(self, application):
         """ Checks invalid response is correctly replied to. """
         data = {}

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,23 +5,21 @@ import pytest
 class Test_check_exchange_info(object):
     """ Test for check_exchange_info() function with proper and improper params. """
 
-    def test_proper_input(self):
-        valid_request, status, response = validators.check_exchange_info("binance")
+    async def test_proper_input(self):
+        valid_request, status, response = await validators.check_exchange_info("binance")
         assert valid_request == True
         assert status == None
-        assert response['exchange-object'] is not None
 
-    def test_invalid_input(self):
-        valid_request, status, response = validators.check_exchange_info("random")
+    async def test_invalid_input(self):
+        valid_request, status, response = await validators.check_exchange_info("random")
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'exchange_error'
 
-
 class Test_check_historical_data(object):
     """ Test for the check_historical_data() function with proper, improper, and empty params. """
 
-    def test_proper_input(self):
+    async def test_proper_input(self):
         """ Checking proper input returns true. """
         data = {
             'exchange': 'binance',
@@ -30,30 +28,45 @@ class Test_check_historical_data(object):
             'start': '2018-01-01 00:00:00',
             'end': '2018-05-01 00:00:00'
         }
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == True
         assert status == None
-        assert response is not None
+        assert response is None
 
-    def test_empty_input(self):
+    async def test_proper_input_with_cfbypass(self):
+        """ Checking proper input returns true. """
+        data = {
+            'exchange': 'binance',
+            'symbol': 'ETH/BTC',
+            'timeframe': '1m',
+            'start': '2018-01-01 00:00:00',
+            'end': '2018-05-01 00:00:00',
+            'cfbypass': True
+        }
+        valid_request, status, response = await validators.check_historical_data(data)
+        assert valid_request == True
+        assert status == None
+        assert response is None
+
+    async def test_empty_input(self):
         """ Checking empty input returns false and proper return. """
         data = {}
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'invalid_request'
 
-    def test_partial_data(self):
+    async def test_partial_data(self):
         """ Checking partial data returns false and proper return. """
         data = {
             'exchange': 'binance',
         }
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'invalid_request'
 
-    def test_unknown_exchange(self):
+    async def test_unknown_exchange(self):
         """ Checking if exchange name is unknown, it returns proper error. """
         data = {
             'exchange': 'random_unknown_name',
@@ -62,12 +75,12 @@ class Test_check_historical_data(object):
             'start': '2018-01-01 00:00:00',
             'end': '2018-05-01 00:00:00'
         }
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'exchange_error'
 
-    def test_exchange_support_for_historical_data(self):
+    async def test_exchange_support_for_historical_data(self):
         """ Checking if valid exchange has support for historical data. """
         data = {
             'exchange': 'coinmarketcap',
@@ -76,12 +89,12 @@ class Test_check_historical_data(object):
             'start': '2018-01-01 00:00:00',
             'end': '2018-05-01 00:00:00'
         }
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'historical_error'
 
-    def test_exchange_support_for_timeframe(self):
+    async def test_exchange_support_for_timeframe(self):
         """ Checking if valid exchange has support for the given timeframe. """
         data = {
             'exchange': 'binance',
@@ -90,12 +103,12 @@ class Test_check_historical_data(object):
             'start': '2018-01-01 00:00:00',
             'end': '2018-05-01 00:00:00'
         }
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'timeframe_error'
 
-    def test_exchange_support_for_symbol(self):
+    async def test_exchange_support_for_symbol(self):
         """ Checking if valid exchange has support for the given symbol. """
         data = {
             'exchange': 'binance',
@@ -104,7 +117,7 @@ class Test_check_historical_data(object):
             'start': '2018-01-01 00:00:00',
             'end': '2018-05-01 00:00:00'
         }
-        valid_request, status, response = validators.check_historical_data(data)
+        valid_request, status, response = await validators.check_historical_data(data)
         assert valid_request == False
         assert status == 400
         assert response['error'] == 'symbol_error'


### PR DESCRIPTION
Currently working to bypass the CloudFare DDOS verification system by utilizing [`cfscrape`](https://github.com/Anorov/cloudflare-scrape) in conjunction with [`ccxt`](https://github.com/ccxt/ccxt) as shown in their example [`bypass-cloudflare.py`](https://github.com/ccxt/ccxt/blob/master/examples/py/bypass-cloudflare.py). 

This branch has also:

* Fixed a small bug inside the `api.py` file where `config.yml` was not loading properly. 
* Added further documentation for the `validators.py` file.
* Added more information for the API documentation; specifically the return for historical data retrieval.
* Updated the requirements `base.txt` and `dev.txt` to include `cfscrape`. 
* Change the Dockerfile to contain both Python and NodeJS (Node is used by `cfscrape`). 
* Modified `utils.py` so that `historical_data()` can either be async, or sync with `cfscrape`. 
* Created `/examples` folder on root of the project.

Requires a few to-dos to be taken care. 