### PR TITLE
WIP - Changed Dockerfile to use python3-slim for smaller container size. 

### DIFF
--- a/CryptoBook/api.py
+++ b/CryptoBook/api.py
@@ -48,4 +48,4 @@ async def api_historical_data(request):
 # 'pragma' line below insures Coverall does not bother checking this function for coverage.
 if __name__ == '__main__': # pragma: no cover
     host, port = load_config()
-    app.run(host=config['host'], port=config['port'])
+    app.run(host=host, port=port)

--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from dateutil.parser import parse
 import pandas as pd
+import cfscrape
 import asyncio
 import aiohttp
 import ccxt
@@ -56,6 +57,7 @@ async def historical_data(exchange, symbol, timeframe, start, end, exchange_obje
     if exchange_object:
         ex = exchange_object
         ex.enableRateLimit = False
+        ex.session = cfscrape.create_scraper()
     else:
         ex = getattr (ccxt, exchange) ()
 

--- a/CryptoBook/validators.py
+++ b/CryptoBook/validators.py
@@ -10,10 +10,10 @@ def check_exchange_info(exchange):
     Args:
         exchange (str): The name of the exchange to check.
 
-    Returns:
-        bool: Boolean representing whether or not check was successfull or failure.
-        int: HTTP code corresponding to the data validation. None if return bool above is true.
-        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
+    :returns:
+        - **valid_request** (*bool*): Boolean representing whether or not check was successfull or failure.
+        - **status** (*int*): HTTP code corresponding to the data validation. None if return bool above is true.
+        - **response** (*dict*): The response by the validator; either an error, or the loaded ccxt exchange object.
     """
 
     try:
@@ -30,10 +30,10 @@ def check_historical_data(request):
     Args:
         request (dict): The request sent into the server.
 
-    Returns:
-        bool: Boolean representing whether or not check was successfull or failure.
-        int: HTTP code corresponding to the data validation. None if return bool above is true.
-        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
+    :returns:
+        - **valid_request** (*bool*): Boolean representing whether or not check was successfull or failure.
+        - **status** (*int*): HTTP code corresponding to the data validation. None if return bool above is true.
+        - **response** (*dict*): The response by the validator; either an error, or the loaded ccxt exchange object.
     """
 
     # Creates the validator class and schema to check the requests' params.

--- a/CryptoBook/validators.py
+++ b/CryptoBook/validators.py
@@ -5,7 +5,17 @@ from sanic.response import json
 import ccxt
 
 def check_exchange_info(exchange):
-    # Checks to see if the exchange is valid.
+    """ Checks to see if the exchange is valid.
+
+    Args:
+        exchange (str): The name of the exchange to check.
+
+    Returns:
+        bool: Boolean representing whether or not check was successfull or failure.
+        int: HTTP code corresponding to the data validation. None if return bool above is true.
+        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
+    """
+
     try:
         ex = getattr (ccxt, exchange) ()
     except AttributeError:
@@ -22,7 +32,8 @@ def check_historical_data(request):
 
     Returns:
         bool: Boolean representing whether or not check was successfull or failure.
-        dict: Errors corresponding to the data validation. Empty if return bool is true.
+        int: HTTP code corresponding to the data validation. None if return bool above is true.
+        dict: The response by the validator; either an error, or the loaded ccxt exchange object.
     """
 
     # Creates the validator class and schema to check the requests' params.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM nikolaik/python-nodejs:latest
 
 # Exposes this container's port 9900 to other containers.
 EXPOSE 9900

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM nikolaik/python-nodejs:latest
+FROM python:3
+
+# Install NodeJS to the Alpine container (depedency).
+RUN apt-get -y update
+RUN apt-get -y install nodejs
 
 # Exposes this container's port 9900 to other containers.
 EXPOSE 9900

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM python:3
+FROM python:3-slim
+
+# Install g++ and make to ensure dependencies install with python:3-slim.
+RUN apt-get -y update
+RUN apt-get -y install g++ make
 
 # Install NodeJS to the Alpine container (depedency).
-RUN apt-get -y update
 RUN apt-get -y install nodejs
 
 # Exposes this container's port 9900 to other containers.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,7 +88,50 @@ Historical Data
             "symbol": "ETH/BTC",
             "timeframe": "1m",
             "start": "2018-01-01 00:00:00",
-            "end": "2018-05-01 00:00:00"
+            "end": "2018-01-01 00:05:00"
+        }
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 543
+        Content-Type: application/json
+        Keep-Alive: 5
+
+        {
+            "Close": {
+                "0": 0.05352,
+                "...",
+                "5": 0.053588
+            },
+            "High": {
+                "0": 0.053613,
+                "...",
+                "5": 0.053654
+            },
+            "Low": {
+                "0": 0.053496,
+                "...",
+                "5": 0.053567
+            },
+            "Open": {
+                "0": 0.053586,
+                "...",
+                "5": 0.053573
+            },
+            "Time": {
+                "0": 1514764800000,
+                "...",
+                "5": 1514765100000
+            },
+            "Volume": {
+                "0": 162.312,
+                "...",
+                "5": 194.333
+            }
         }
 
     :jsonparam string exchange: The name of the exchange.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ pyyaml
 aiohttp
 pandas
 cerberus
+cfscrape

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@ pyyaml
 aiohttp
 pandas
 cerberus
+cfscrape
 
 pytest
 pytest-asyncio


### PR DESCRIPTION
**This is dependent on #16 -- please merge only after #16 is merged.**

As noted in [#16 discussion](https://github.com/Waultics/CryptoBook/pull/16#discussion_r292661966), the container's size is currently 1.4gb -- which is absolutely huge for such a small application. This PR changes the container image to `python:3-slim` as oppose to `python:3`, bringing the size down to half, at a more manageable 522mb.

The `python:3-slim` image uses Alpine Linux stripped out to basically its bare bones. In the discussion on #16 there was a mention of the build failure, but that was due to the image missing `g++` and `make` dependencies. Change to the Dockerfile to add those utilities to the build resolves the build issues. 

<img width="1222" alt="Screen Shot 2019-06-11 at 5 29 08 PM" src="https://user-images.githubusercontent.com/2829082/59308219-7775a280-8c6e-11e9-93cd-73d4df1c493c.png">
 