### PR TITLE
Changed Dockerfile for smaller container size (1.4gb to 522mb).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM python:3
+FROM python:3-slim
+
+# Install g++ and make to ensure dependencies install with python:3-slim.
+RUN apt-get -y update
+RUN apt-get -y install g++ make
+
+# Install NodeJS to the Alpine container (depedency).
+RUN apt-get -y install nodejs
 
 # Exposes this container's port 9900 to other containers.
 EXPOSE 9900


### PR DESCRIPTION
As noted in [#16 discussion](https://github.com/Waultics/CryptoBook/pull/16#discussion_r292661966), the container's size is currently 1.4gb -- which is absolutely huge for such a small application. This PR changes the container image to `python:3-slim` as oppose to `python:3`, bringing the size down to half, at a more manageable 522mb.

The `python:3-slim` image uses Alpine Linux stripped out to basically its bare bones. In the discussion on #16 there was a mention of the build failure, but that was due to the image missing `g++` and `make` dependencies. Change to the Dockerfile to add those utilities to the build resolves the build issues. 

<img width="1222" alt="Screen Shot 2019-06-11 at 5 29 08 PM" src="https://user-images.githubusercontent.com/2829082/59308219-7775a280-8c6e-11e9-93cd-73d4df1c493c.png">
 