### PR TITLE
Close exchange connection directly after asyncio.gather(...) is executed

### DIFF
--- a/CryptoBook/utils.py
+++ b/CryptoBook/utils.py
@@ -124,6 +124,8 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
         responses = await asyncio.gather(
             *[ex.fetch_ohlcv(symbol, timeframe, time) for time in times]
         )
+        # Must close connection with market if using ccxt asynchronously.
+        ex.close()
 
     # Appends all of our results to the DataFrame.
     dataframes = [pd.DataFrame(data=response, columns=header) for response in responses]
@@ -134,10 +136,6 @@ async def historical_data(exchange, symbol, timeframe, start, end, cfbypass=Fals
 
     # Removes duplicates due to server responding with (sometimes) duplicate values.
     df = df.drop_duplicates(keep="first")
-
-    # Must close connection with market if using ccxt asynchronously.
-    if not cfbypass:
-        await ex.close()
 
     # Return the DataFrame as a dictionary.
     return df.to_dict(orient="split")


### PR DESCRIPTION
For some odd reason, not closing the exchange connection directly after issuing the `asyncio.gather(...)` command results in the following error:

> oculi-cryptobook | binance requires to release all resources with an explicit call to the .close() coroutine. If you are using the exchange instance with async coroutines, add exchange.close() to your code into a place when you're done with the exchange and don't need the exchange instance anymore (at the end of your async coroutine).
oculi-cryptobook | ERROR:asyncio:Unclosed client session
oculi-cryptobook | client_session: <aiohttp.client.ClientSession object at 0x7fe91ba2f208>
oculi-cryptobook | ERROR:asyncio:Unclosed connector

Moving the `ex.close()` statement to right after the `.gather(...)` function call prevents the error from popping up and allows calls to run without server error.