### PR TITLE
Installed OpenSSL 1.1.1, and changed Dockerfile back to python:3 image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3
 
+# Ensuring we have the latest Debian packages.
+RUN apt-get -y update && apt-get -y upgrade
+
 # Installing OpenSSL 1.1.1.
 RUN wget https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
     tar -zxf openssl-1.1.1a.tar.gz
@@ -13,7 +16,6 @@ RUN ./config && \
     ldconfig
 
 # Installing NodeJS for CloudFlare captcha bypass.
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get -y install nodejs
 
 # Exposes this container's port 9900 to other containers.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM python:3-slim
+FROM python:3
 
-# Install g++ and make to ensure dependencies install with python:3-slim.
-RUN apt-get -y update
-RUN apt-get -y install g++ make
+# Installing OpenSSL 1.1.1.
+RUN wget https://www.openssl.org/source/openssl-1.1.1a.tar.gz && \
+    tar -zxf openssl-1.1.1a.tar.gz
+WORKDIR openssl-1.1.1a
+RUN ./config && \
+    make && \
+    make test && \
+    mv /usr/bin/openssl ~/tmp && \
+    make install && \
+    ln -s /usr/local/bin/openssl /usr/bin/openssl && \
+    ldconfig
 
-# Install NodeJS to the Alpine container (depedency).
+# Installing NodeJS for CloudFlare captcha bypass.
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get -y install nodejs
-
-# Upgrade Alpine's system.
-RUN apt-get -y update
-RUN apt-get -y upgrade
-
-# Install NodeJS na OpenSSL to the Alpine container (depedency).
-RUN apt-get -y install openssl nodejs
 
 # Exposes this container's port 9900 to other containers.
 EXPOSE 9900


### PR DESCRIPTION
OpenSSL version 1.1.1 is a dependency of `cfscrape`, and therefore, unfortunately, we won't be able to utilize Docker image `python:3-slim` or `python:3-alpine`. 